### PR TITLE
Fix signup capacity enforcement and add regression tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
 fastapi
 uvicorn
+pytest
+httpx

--- a/src/app.py
+++ b/src/app.py
@@ -105,6 +105,13 @@ def signup_for_activity(activity_name: str, email: str):
             detail="Student is already signed up"
         )
 
+    # Validate activity still has available spots
+    if len(activity["participants"]) >= activity["max_participants"]:
+        raise HTTPException(
+            status_code=400,
+            detail="Activity is full"
+        )
+
     # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}

--- a/tests/test_signup_capacity.py
+++ b/tests/test_signup_capacity.py
@@ -1,0 +1,37 @@
+from copy import deepcopy
+
+from fastapi.testclient import TestClient
+
+from src.app import activities, app
+
+
+client = TestClient(app)
+_original_activities = deepcopy(activities)
+
+
+def setup_function():
+    activities.clear()
+    activities.update(deepcopy(_original_activities))
+
+
+def test_signup_rejects_when_activity_is_full():
+    activities["Chess Club"]["participants"] = [
+        f"student{i}@mergington.edu" for i in range(activities["Chess Club"]["max_participants"])
+    ]
+
+    response = client.post(
+        "/activities/Chess%20Club/signup?email=new-student@mergington.edu"
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Activity is full"
+
+
+def test_signup_allows_when_activity_has_space():
+    response = client.post(
+        "/activities/Chess%20Club/signup?email=new-student@mergington.edu"
+    )
+
+    assert response.status_code == 200
+    assert response.json()["message"] == "Signed up new-student@mergington.edu for Chess Club"
+    assert "new-student@mergington.edu" in activities["Chess Club"]["participants"]


### PR DESCRIPTION
## Summary
Prevent over-capacity enrollments by enforcing `max_participants` in the signup endpoint.

## What changed
- Added backend validation in signup flow to return `400` with `Activity is full` when capacity is reached.
- Added regression tests to cover:
  - rejection when an activity is full
  - successful signup when capacity is available
- Added test dependencies required to run the new tests.

## Validation
- Ran `pytest -q`
- Result: `2 passed`

Fixes #10